### PR TITLE
CDR-1442 fix class not found

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -35,7 +35,7 @@ jobs:
           cache: 'maven'
 
       - name: Build
-        run: mvn clean verify spring-boot:build-image
+        run: mvn --batch-mode --update-snapshots clean verify spring-boot:build-image
 
       - name: Spotless
         run: mvn spotless:check

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -13,10 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ '21' ]
-
     steps:
 
       - name: Checkout
@@ -24,29 +20,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Login to GitLab
+      - name: Docker - Login
         uses: docker/login-action@v3
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Setup Java
+      - name: Setup - Java
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.java }}
+          java-version: '21'
           cache: 'maven'
+
+      - name: Build
+        run: mvn clean verify spring-boot:build-image
 
       - name: Spotless
         run: mvn spotless:check
 
-      - name: Build with Maven
-        run: mvn clean verify spring-boot:build-image
-
-      - name: Build and push
+      - name: Docker - Push
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           VERSION=$(mvn help:evaluate -Dexpression="project.version" -q -DforceStdout) 
-          echo ${VERSION}
           docker push ehrbase/migration-tool:${VERSION}
-  

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ The target database needs to be prepared according to the instructions in the [E
 
 ## Performing the migration
 
-The migration can be run directly from the source code, or the provided docker image.
+The migration can be run directly from the source code, or the provided docker image. As a naming convention an `export`
+datasource represents an EHRbase 0.x.x database where an `import` datasource represents an EHRbase 2 database.
+
 The properties must be adjusted according to the set-up:
 
 ### Spring boot
@@ -28,10 +30,10 @@ mvn package
 
 java -jar application/target/migration-tool.jar \
 -Dmode=DB2DB \
--Dspring.datasource.import.url=jdbc:postgresql://localhost:5432/ehrbase_import \
+-Dspring.datasource.import.url=jdbc:postgresql://localhost:5432/ehrbase_new \
 -Dspring.datasource.import.username=ehrbase \
 -Dspring.datasource.import.password=ehrbase \
--Dspring.datasource.export.url=jdbc:postgresql://localhost:5432/ehrbase_export \
+-Dspring.datasource.export.url=jdbc:postgresql://localhost:5432/ehrbase_old \
 -Dspring.datasource.export.username=ehrbase \
 -Dspring.datasource.export.password=ehrbase \
 -Dimport.ehrbase-db-user=ehrbase_restricted
@@ -43,10 +45,10 @@ mvn verify
 
 docker run ehrbase/migration-tool:1.1.0 \
 -e mode=DB2DB \
--e spring.datasource.import.url=jdbc:postgresql://localhost:5432/ehrbase_import \
+-e spring.datasource.import.url=jdbc:postgresql://localhost:5432/ehrbase_new \
 -e spring.datasource.import.username=ehrbase \
 -e spring.datasource.import.password=ehrbase \
--e spring.datasource.export.url=jdbc:postgresql://localhost:5432/ehrbase_export \
+-e spring.datasource.export.url=jdbc:postgresql://localhost:5432/ehrbase_old \
 -e spring.datasource.export.username=ehrbase \
 -e spring.datasource.export.password=ehrbase \
 -e import.ehrbase-db-user=ehrbase_restricted

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -16,11 +16,14 @@
   <name>EHRbase Migration Tool Application</name>
 
   <properties>
-    <image.name>ehrbase/migration-tool</image.name>
-    <image.tag>${project.version}</image.tag>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <java.version>21</java.version>
+
+    <skipTests>false</skipTests>
+
+    <image.name>ehrbase/migration-tool</image.name>
+    <image.tag>${project.version}</image.tag>
   </properties>
 
   <dependencyManagement>
@@ -35,14 +38,16 @@
     </dependencies>
   </dependencyManagement>
 
-
   <dependencies>
 
+    <!-- Compile -->
     <dependency>
       <groupId>org.ehrbase.migration</groupId>
       <artifactId>migration-service</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Test -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -56,6 +61,10 @@
       <artifactId>wiremock</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-impl</artifactId>
     </dependency>
@@ -64,13 +73,10 @@
       <artifactId>jjwt-jackson</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-jupiter</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
+
   </dependencies>
 
   <build>
@@ -84,6 +90,18 @@
             <arg>-parameters</arg>
           </compilerArgs>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
@@ -132,6 +150,7 @@
           <skip>false</skip>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
@@ -172,12 +191,21 @@
             <goals>
               <goal>test</goal>
             </goals>
+            <configuration>
+              <skipTests>${skipTests}</skipTests>
+              <includes>
+                <include>**/*Test.java</include>
+              </includes>
+            </configuration>
           </execution>
         </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skipITs>${skipTests}</skipITs>
+        </configuration>
         <executions>
           <execution>
             <id>integration-test</id>
@@ -193,19 +221,6 @@
                 <include>**/*IT.java</include>
               </includes>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/application/src/test/java/org/ehrbase/migration/application/MigrationToolIT.java
+++ b/application/src/test/java/org/ehrbase/migration/application/MigrationToolIT.java
@@ -83,8 +83,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @Testcontainers
-@ContextConfiguration(initializers = MigrationToolTestIT.Initializer.class)
-class MigrationToolTestIT {
+@ContextConfiguration(initializers = MigrationToolIT.Initializer.class)
+class MigrationToolIT {
 
     protected static GenericContainer postgresOld;
 
@@ -244,7 +244,7 @@ class MigrationToolTestIT {
     }
 
     @NotNull
-    private MigrationToolTestIT.EhrExampleData createExampleEhr(
+    private MigrationToolIT.EhrExampleData createExampleEhr(
             String exampleCompositionName,
             DefaultRestClient restClient1,
             String committer1Subject,
@@ -356,7 +356,7 @@ class MigrationToolTestIT {
                 .extracting(
                         r -> r.getVersionId().getVersionTreeId().getValue(),
                         r -> r.getAudits().getFirst().getChangeType().getValue(),
-                        MigrationToolTestIT::getAuditCommitterUuid,
+                        MigrationToolIT::getAuditCommitterUuid,
                         r -> ((PartyIdentified) r.getAudits().getFirst().getCommitter()).getName())
                 .containsExactly(expectedAudits);
     }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -87,6 +87,7 @@
         <version>2.11.5</version>
       </dependency>
 
+      <!-- Test -->
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <module>service</module>
     <module>application</module>
   </modules>
+
   <build>
     <plugins>
       <plugin>
@@ -30,27 +31,6 @@
               <file>./spotless-lic-header</file>
             </licenseHeader>
           </java>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>docker</id>
-            <goals>
-              <goal>build-image-no-fork</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -16,7 +16,11 @@
   <name>EHRbase Migration Tool Service</name>
 
   <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <java.version>21</java.version>
+
+    <skipTests>false</skipTests>
   </properties>
 
   <dependencyManagement>
@@ -32,6 +36,8 @@
   </dependencyManagement>
 
   <dependencies>
+
+    <!-- Compile -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
@@ -87,6 +93,7 @@
       <artifactId>zip4j</artifactId>
     </dependency>
 
+    <!-- Test -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -123,6 +130,28 @@
           </java>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>docker</id>
+            <goals>
+              <goal>build-image-no-fork</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
@@ -163,12 +192,21 @@
             <goals>
               <goal>test</goal>
             </goals>
+            <configuration>
+              <skipTests>${skipTests}</skipTests>
+              <includes>
+                <include>**/*Test.java</include>
+              </includes>
+            </configuration>
           </execution>
         </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skipITs>${skipTests}</skipITs>
+        </configuration>
         <executions>
           <execution>
             <id>integration-test</id>
@@ -187,27 +225,7 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>docker</id>
-            <goals>
-              <goal>build-image-no-fork</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
+
     </plugins>
   </build>
 

--- a/service/src/main/java/org/ehrbase/migration/importer/v4/FlywayService.java
+++ b/service/src/main/java/org/ehrbase/migration/importer/v4/FlywayService.java
@@ -19,8 +19,6 @@ package org.ehrbase.migration.importer.v4;
 
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.flywaydb.core.Flyway;
@@ -30,6 +28,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -61,8 +61,8 @@ public class FlywayService {
     }
 
     public void migrateSchema(
-            @Nonnull String schema,
-            @Nonnull String location,
+            @NonNull String schema,
+            @NonNull String location,
             @Nullable String baseline,
             @Nullable String schemaPlaceholder) {
         FluentConfiguration config =


### PR DESCRIPTION
## Description

Uses `nullable/nonnull` annotation from spring instead of `javax.annotations` because this was missing on the classpath. Also explained the properties import/export a little bit more. For more infos see https://github.com/ehrbase/migration-tool/issues/7. 

Further more fixed the maven setup so that the integration tests are running only once, using the failsafe plugin and not a second time by surefire. During this change a new `skipTests` property was added as well.